### PR TITLE
Kaleidoscope interactions

### DIFF
--- a/Scenes/Experimental/Amy/TestSprite.gd
+++ b/Scenes/Experimental/Amy/TestSprite.gd
@@ -12,5 +12,5 @@ func _ready():
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
+func _process(_delta):
 	rotation = rad2deg(deg2rad(rotation) + 0.0001);

--- a/Scenes/Kaleidoscope/Gemstones/CircleGemstone.tscn
+++ b/Scenes/Kaleidoscope/Gemstones/CircleGemstone.tscn
@@ -7,6 +7,7 @@
 radius = 11.0
 
 [node name="CircleGemstone" instance=ExtResource( 2 )]
+sprite_texture = ExtResource( 1 )
 
 [node name="Sprite" parent="." index="0"]
 texture = ExtResource( 1 )

--- a/Scenes/Kaleidoscope/Gemstones/DiamondGemstone.tscn
+++ b/Scenes/Kaleidoscope/Gemstones/DiamondGemstone.tscn
@@ -4,6 +4,7 @@
 [ext_resource path="res://Assets/Sourced/Textures/element_blue_diamond.png" type="Texture" id=2]
 
 [node name="DiamondGemstone" instance=ExtResource( 1 )]
+sprite_texture = ExtResource( 2 )
 
 [node name="Sprite" parent="." index="0"]
 texture = ExtResource( 2 )

--- a/Scenes/Kaleidoscope/Gemstones/PolygonGemstone.tscn
+++ b/Scenes/Kaleidoscope/Gemstones/PolygonGemstone.tscn
@@ -4,6 +4,7 @@
 [ext_resource path="res://Scenes/Kaleidoscope/Gemstone.tscn" type="PackedScene" id=2]
 
 [node name="PolygonGemstone" instance=ExtResource( 2 )]
+sprite_texture = ExtResource( 1 )
 
 [node name="Sprite" parent="." index="0"]
 texture = ExtResource( 1 )

--- a/Scenes/Kaleidoscope/Gemstones/RectangleGemstone.tscn
+++ b/Scenes/Kaleidoscope/Gemstones/RectangleGemstone.tscn
@@ -7,6 +7,7 @@
 extents = Vector2( 32, 15 )
 
 [node name="RectangleGemstone" instance=ExtResource( 2 )]
+sprite_texture = ExtResource( 1 )
 
 [node name="Sprite" parent="." index="0"]
 texture = ExtResource( 1 )

--- a/Scenes/Kaleidoscope/Gemstones/SquareGemstone.tscn
+++ b/Scenes/Kaleidoscope/Gemstones/SquareGemstone.tscn
@@ -7,6 +7,7 @@
 extents = Vector2( 16, 16 )
 
 [node name="SquareGemstone" instance=ExtResource( 1 )]
+sprite_texture = ExtResource( 2 )
 
 [node name="Sprite" parent="." index="0"]
 texture = ExtResource( 2 )

--- a/Scenes/Kaleidoscope/KaleidoscopeViewport.gd
+++ b/Scenes/Kaleidoscope/KaleidoscopeViewport.gd
@@ -1,7 +1,22 @@
 extends ViewportContainer
+const MAX_ROTATION_STEP = 5 # maximum rotation that can be applied at each movement
+const MOUSE_SENSITIVITY = 0.001 # sensitivity of the mouse
+const CAPTURED_MOUSE_SENSITIVITY = 0.5# sensitivity of the mouse in captured mode (somewhat the speed is different in each mode)
+var next_rotation = 0 # the next rotation to apply to the tumbler
 
 
-func _process(_delta : float) -> void:
-	var center_point : Vector2 = rect_size / 2.0
-	var mouse_angle : float = center_point.angle_to_point(get_global_mouse_position())
-	$Viewport/TumblerScene.rotation = mouse_angle
+func _physics_process(delta : float) -> void:
+	$Viewport/TumblerScene.rotate(next_rotation * delta)
+	next_rotation = 0
+
+
+func _input(event : InputEvent) -> void:
+	if event is InputEventMouseMotion:
+		var x_speed : float
+		
+		if Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
+			x_speed = event.relative.x * CAPTURED_MOUSE_SENSITIVITY
+		else:
+			x_speed = event.speed.x * MOUSE_SENSITIVITY
+		print(x_speed)
+		next_rotation = clamp(x_speed, -MAX_ROTATION_STEP, MAX_ROTATION_STEP)

--- a/Scenes/Kaleidoscope/KaleidoscopeViewport.gd
+++ b/Scenes/Kaleidoscope/KaleidoscopeViewport.gd
@@ -1,7 +1,9 @@
 extends ViewportContainer
+const ROTATION_STEP = 3 # rotation step when using keyboard or scroll wheel to move the kaleidoscope
 const MAX_ROTATION_STEP = 5 # maximum rotation that can be applied at each movement
 const MOUSE_SENSITIVITY = 0.001 # sensitivity of the mouse
 const CAPTURED_MOUSE_SENSITIVITY = 0.5# sensitivity of the mouse in captured mode (somewhat the speed is different in each mode)
+
 var next_rotation = 0 # the next rotation to apply to the tumbler
 
 
@@ -18,5 +20,11 @@ func _input(event : InputEvent) -> void:
 			x_speed = event.relative.x * CAPTURED_MOUSE_SENSITIVITY
 		else:
 			x_speed = event.speed.x * MOUSE_SENSITIVITY
-		print(x_speed)
 		next_rotation = clamp(x_speed, -MAX_ROTATION_STEP, MAX_ROTATION_STEP)
+	
+
+	elif event is InputEventMouseButton or event is InputEventKey:
+		if event.get_action_strength("turn_tumbler_right") > 0: #using get_action_strength instead of is_action_pressed so you can keep the key pressed
+			next_rotation = ROTATION_STEP
+		elif event.get_action_strength("turn_tumbler_left") > 0:
+			next_rotation = -ROTATION_STEP

--- a/project.godot
+++ b/project.godot
@@ -33,6 +33,21 @@ window/size/height=1080
 
 common/drop_mouse_on_gui_input_disabled=true
 
+[input]
+
+turn_tumbler_left={
+"deadzone": 0.5,
+"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":5,"pressed":false,"doubleclick":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":65,"unicode":0,"echo":false,"script":null)
+ ]
+}
+turn_tumbler_right={
+"deadzone": 0.5,
+"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":4,"pressed":false,"doubleclick":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":68,"unicode":0,"echo":false,"script":null)
+ ]
+}
+
 [physics]
 
 common/enable_pause_aware_picking=true


### PR DESCRIPTION
add interraction to the kaleidoscope by using mouse X movement (instead of angle to the center of the screen) works in mouse captured mode too (may actually work better in this mode btw)

can also use mouse scroll wheel and keyboard A/D or Q/D if AZERTY layout

+minor change to gem stone -> i copied the default texture assigned to the child sprite node to the sprite_texture export var of the gemstone for consistency and clarity