### PR TITLE
added a raycast to the player controller and ViewCollider

### DIFF
--- a/Scenes/Dreamscape.tscn
+++ b/Scenes/Dreamscape.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://Assets/Quixel/sfknaeoa_4K_Albedo.jpg" type="Texture" id=1]
 [ext_resource path="res://Scenes/Player.tscn" type="PackedScene" id=2]
 [ext_resource path="res://Scripts/Dreamscape.gd" type="Script" id=3]
+[ext_resource path="res://Themes/TitleFont.tres" type="DynamicFont" id=4]
 
 [sub_resource type="SpatialMaterial" id=1]
 albedo_texture = ExtResource( 1 )
@@ -26,3 +27,20 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1.84945, 0.244885, 0, -14.9742 )
 
 [node name="Player Controller" parent="." instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0301998, 1.93416, 8.91611 )
+
+[node name="TestViewColliderUI" type="CanvasLayer" parent="."]
+__meta__ = {
+"_editor_description_": "ui just to test the looking at system works fine
+
+can be deleted after"
+}
+
+[node name="Label" type="Label" parent="TestViewColliderUI"]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -150.0
+margin_bottom = -136.0
+custom_fonts/font = ExtResource( 4 )
+
+[connection signal="started_looking_at" from="Player Controller" to="." method="_on_Player_Controller_started_looking_at"]

--- a/Scenes/DreamscapeEnvironment.tscn
+++ b/Scenes/DreamscapeEnvironment.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://Assets/AllSky/AllSkyFree_Skyboxes/AllSky_Night_MoonBurst Equirect.png" type="Texture" id=1]
 [ext_resource path="res://Assets/AllSky/AllSkyFree_DemoLandsacpe.tscn" type="PackedScene" id=2]
 [ext_resource path="res://Scenes/Dreamscape.tscn" type="PackedScene" id=3]
+[ext_resource path="res://Scenes/ViewCollider.tscn" type="PackedScene" id=4]
 
 [sub_resource type="PanoramaSky" id=1]
 panorama = ExtResource( 1 )
@@ -32,6 +33,10 @@ glow_bloom = 0.63
 glow_blend_mode = 0
 glow_hdr_threshold = 0.44
 glow_bicubic_upscale = true
+
+[sub_resource type="CapsuleShape" id=6]
+radius = 0.5
+height = 5.0
 
 [sub_resource type="SpatialMaterial" id=4]
 render_priority = -1
@@ -64,6 +69,29 @@ visible = false
 [node name="Dreamscape" parent="." instance=ExtResource( 3 )]
 
 [node name="TestGlowyThings" type="Spatial" parent="."]
+
+[node name="ViewCollider" parent="TestGlowyThings" instance=ExtResource( 4 )]
+transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -5.348, 2.88957, -0.463445 )
+collider_type = 1
+
+[node name="CollisionShape" parent="TestGlowyThings/ViewCollider" index="0"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.014472, 0.0481124, 0 )
+shape = SubResource( 6 )
+
+[node name="ViewCollider2" parent="TestGlowyThings" instance=ExtResource( 4 )]
+transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -1.83369, 2.88957, -11.916 )
+
+[node name="CollisionShape" parent="TestGlowyThings/ViewCollider2" index="0"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0723314, 1.87253, 0 )
+shape = SubResource( 6 )
+
+[node name="ViewCollider3" parent="TestGlowyThings" instance=ExtResource( 4 )]
+transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.619192, 2.88957, 4.53638 )
+collider_type = 2
+
+[node name="CollisionShape" parent="TestGlowyThings/ViewCollider3" index="0"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0723314, 1.87253, 0 )
+shape = SubResource( 6 )
 
 [node name="red" type="CSGCylinder" parent="TestGlowyThings"]
 transform = Transform( 0.101, 0, 0, 0, 6, 0, 0, 0, 0.101, -1.83369, 2.88957, -10.1977 )
@@ -107,3 +135,7 @@ light_specular = 0.585
 shadow_enabled = true
 omni_range = 10.0
 omni_attenuation = 1.74
+
+[editable path="TestGlowyThings/ViewCollider"]
+[editable path="TestGlowyThings/ViewCollider2"]
+[editable path="TestGlowyThings/ViewCollider3"]

--- a/Scenes/Player.tscn
+++ b/Scenes/Player.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://Scripts/Player.gd" type="Script" id=1]
+[ext_resource path="res://Scenes/PlayerController.gd" type="Script" id=2]
 
 [sub_resource type="CapsuleShape" id=1]
 radius = 0.5
@@ -9,6 +10,7 @@ radius = 0.5
 extents = Vector3( 0.4, 0.1, 0.4 )
 
 [node name="Player Controller" type="Spatial"]
+script = ExtResource( 2 )
 
 [node name="Player" type="KinematicBody" parent="."]
 script = ExtResource( 1 )
@@ -25,3 +27,8 @@ shape = SubResource( 2 )
 
 [node name="Camera" type="Camera" parent="Player/Pivot"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.183741, 0.461391 )
+
+[node name="LookingAtRayCast" type="RayCast" parent="Player/Pivot/Camera"]
+enabled = true
+cast_to = Vector3( 0, 0, -100 )
+collision_mask = 2

--- a/Scenes/Player.tscn
+++ b/Scenes/Player.tscn
@@ -32,3 +32,5 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.183741, 0.461391 )
 enabled = true
 cast_to = Vector3( 0, 0, -100 )
 collision_mask = 2
+collide_with_areas = true
+collide_with_bodies = false

--- a/Scenes/PlayerController.gd
+++ b/Scenes/PlayerController.gd
@@ -1,0 +1,14 @@
+extends Spatial
+
+signal started_looking_at(object)
+
+var looking_at : PhysicsBody
+
+func _physics_process(_delta):
+	if looking_at != $Player/Pivot/Camera/LookingAtRayCast.get_collider():
+		if looking_at:
+			looking_at.emit_signal("stop_looked_at")
+		looking_at = $Player/Pivot/Camera/LookingAtRayCast.get_collider()
+		emit_signal("started_looking_at", looking_at)
+		if looking_at:
+			looking_at.emit_signal("looked_at")

--- a/Scenes/PlayerController.gd
+++ b/Scenes/PlayerController.gd
@@ -2,7 +2,7 @@ extends Spatial
 
 signal started_looking_at(object)
 
-var looking_at : PhysicsBody
+var looking_at : Area
 
 func _physics_process(_delta):
 	if looking_at != $Player/Pivot/Camera/LookingAtRayCast.get_collider():

--- a/Scenes/ViewCollider.gd
+++ b/Scenes/ViewCollider.gd
@@ -1,0 +1,12 @@
+extends KinematicBody
+
+# even if debugger prints warning signals defined but not emited, they are, do not delete !
+# these signals are emited from the PlayerController when the LookingAtRaycast collide with this ViewCollider
+signal looked_at
+signal stop_looked_at
+
+enum Type {RED , GREEN, BLUE}
+
+
+export(Type) var collider_type
+

--- a/Scenes/ViewCollider.gd
+++ b/Scenes/ViewCollider.gd
@@ -1,4 +1,4 @@
-extends KinematicBody
+extends Area
 
 # even if debugger prints warning signals defined but not emited, they are, do not delete !
 # these signals are emited from the PlayerController when the LookingAtRaycast collide with this ViewCollider

--- a/Scenes/ViewCollider.tscn
+++ b/Scenes/ViewCollider.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://Scenes/ViewCollider.gd" type="Script" id=1]
+
+[sub_resource type="SphereShape" id=1]
+
+[node name="ViewCollider" type="KinematicBody"]
+collision_layer = 2
+collision_mask = 2
+script = ExtResource( 1 )
+__meta__ = {
+"_editor_description_": "a physics body which can be picked by a \"looking at raycast\" (used in Player Controller),
+
+you can use the custom signal looked_at and stop_looked at to know when the player is looking at the collider (those signals are triggered by the Player Controller)"
+}
+
+[node name="CollisionShape" type="CollisionShape" parent="."]
+shape = SubResource( 1 )

--- a/Scenes/ViewCollider.tscn
+++ b/Scenes/ViewCollider.tscn
@@ -4,7 +4,7 @@
 
 [sub_resource type="SphereShape" id=1]
 
-[node name="ViewCollider" type="KinematicBody"]
+[node name="ViewCollider" type="Area"]
 collision_layer = 2
 collision_mask = 2
 script = ExtResource( 1 )

--- a/Scripts/Dreamscape.gd
+++ b/Scripts/Dreamscape.gd
@@ -1,6 +1,7 @@
 extends Spatial
 
 var can_pause = true # to prevent from instantly repausing after unpaused from the pause menu by pressing ui_cancel
+var collision_viewer_types = {0: "RED" , 1: "GREEN", 2: "BLUE"} # list of types defined in ViewColiider
 
 func _process(_delta):
 	# cannot repause before releasing the key once
@@ -9,3 +10,10 @@ func _process(_delta):
 		PauseMenuController.paused = true
 	else:
 		can_pause = true
+
+
+func _on_Player_Controller_started_looking_at(object):
+	if object:
+		$TestViewColliderUI/Label.text = "Looking At : %s" % collision_viewer_types[object.collider_type]
+	else:
+		$TestViewColliderUI/Label.text = ""

--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -52,3 +52,4 @@ func _physics_process(delta):
 	velocity = move_and_slide(velocity, Vector3.UP, true)
 	if Input.is_action_pressed("jump") and is_on_floor():
 		velocity.y = jump_force
+


### PR DESCRIPTION
both use the collision layer 2

the collider use a "collider_type" export var which is an enum to be used as a kind of group to distinguish the color to be affected by it (not sure if absolutely usefull but it's there)

they also provides 2 signals "looked_at" and "stop_looked_at" which are triggered by the LookAtRaycast when it picks it

the LookAtRaycast also provide signal to communicate when it start looking at a new target (including null if looking at nothing in particular)

can be tested in DreamScapeEnvironnment or MainKaleidoscope (need to press k to disable the kaleidoscope in order to see the text appear)